### PR TITLE
Fixed the build errors; prop is from doc; deepmerge generic extends o…

### DIFF
--- a/src/collections/QuestionSets/tests/mock.ts
+++ b/src/collections/QuestionSets/tests/mock.ts
@@ -1,4 +1,4 @@
-import { QuestionSet } from 'payload/generated-types'
+import { QuestionSet } from '@elilemons/diva-score-lib'
 
 export const mockQuestionSets: Array<Partial<QuestionSet>> = [
   {

--- a/src/collections/Surveys/tests/spec.ts
+++ b/src/collections/Surveys/tests/spec.ts
@@ -1,5 +1,4 @@
-import { Doc, UserOnRequest } from '@elilemons/diva-score-lib'
-import { Admin, Survey } from 'payload/generated-types'
+import { Admin, Doc, Survey, UserOnRequest } from '@elilemons/diva-score-lib'
 import Surveys from '..'
 import { deleteSurvey, getAdmin } from '../../../tests/helpers'
 import QuestionSets from '../../QuestionSets'
@@ -55,7 +54,7 @@ describe('Surveys', () => {
     })
 
     it('should have set the user to the test admin user', () => {
-      expect(testSurvey.surveyUser).toBe(admin.id)
+      expect(testSurvey.doc.surveyUser).toBe(admin.user.id)
     })
 
     it('should not allow the user to create more than one survey a day', async () => {

--- a/src/tests/helpers.ts
+++ b/src/tests/helpers.ts
@@ -1,5 +1,4 @@
-import { UserOnRequest } from '@elilemons/diva-score-lib'
-import { Admin } from 'payload/generated-types'
+import { Admin, UserOnRequest } from '@elilemons/diva-score-lib'
 import testCredentials from '../collections/Admins/tests/credentials'
 import Surveys from '../collections/Surveys'
 

--- a/src/utils/deepMerge.ts
+++ b/src/utils/deepMerge.ts
@@ -12,7 +12,7 @@ export function isObject(item: unknown): boolean {
  * @param target
  * @param ...sources
  */
-export default function deepMerge<T, R>(target: T, source: R): T {
+export default function deepMerge<T extends object, R extends object>(target: T, source: R): T {
   const output = { ...target }
   if (isObject(target) && isObject(source)) {
     Object.keys(source).forEach((key) => {


### PR DESCRIPTION
- Moved from 'generated-types' to lib
- props needed to be accessed from doc, ex: `obj.doc.prop` not `obj.prop`
- In Deepmerge, generics needed to extend `object`